### PR TITLE
Harden web server security

### DIFF
--- a/.github/workflows/build-executable.yml
+++ b/.github/workflows/build-executable.yml
@@ -2,9 +2,9 @@ name: Package exe with PyInstaller
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master-custom ]
   pull_request:
-    branches: [ master ]
+    branches: [ master-custom ]
 
 
 jobs:

--- a/server/MMVCServerSIO.py
+++ b/server/MMVCServerSIO.py
@@ -138,8 +138,8 @@ if __name__ == "MMVCServerSIO":
     mp.freeze_support()
 
     voiceChangerManager = VoiceChangerManager.get_instance(voiceChangerParams)
-    app_fastapi = MMVC_Rest.get_instance(voiceChangerManager, voiceChangerParams, PORT, args.allowed_origins)
-    app_socketio = MMVC_SocketIOApp.get_instance(app_fastapi, voiceChangerManager)
+    app_fastapi = MMVC_Rest.get_instance(voiceChangerManager, voiceChangerParams, args.allowed_origins, PORT)
+    app_socketio = MMVC_SocketIOApp.get_instance(app_fastapi, voiceChangerManager, args.allowed_origins, PORT)
 
 
 if __name__ == "__mp_main__":

--- a/server/MMVCServerSIO.py
+++ b/server/MMVCServerSIO.py
@@ -42,7 +42,6 @@ logger.debug(f"---------------- Booting PHASE :{__name__} -----------------")
 def setupArgParser():
     parser = argparse.ArgumentParser()
     parser.add_argument("--logLevel", type=str, default="error", help="Log level info|critical|error. (default: error)")
-    parser.add_argument("--host", type=str, default='127.0.0.1', help="Specify the IP address for HTTP. Specify 0.0.0.0 to listen on all interfaces.")
     parser.add_argument("-p", type=int, default=18888, help="port")
     parser.add_argument("--https", type=strtobool, default=False, help="use https")
     parser.add_argument("--test_connect", type=str, default="8.8.8.8", help="test connect to detect ip in https mode. default 8.8.8.8")
@@ -64,6 +63,9 @@ def setupArgParser():
     parser.add_argument("--crepe_onnx_tiny", type=str, default="pretrain/crepe_onnx_tiny.onnx", help="path to crepe_onnx_tiny")
     parser.add_argument("--rmvpe", type=str, default="pretrain/rmvpe.pt", help="path to rmvpe")
     parser.add_argument("--rmvpe_onnx", type=str, default="pretrain/rmvpe.onnx", help="path to rmvpe onnx")
+
+    parser.add_argument("--host", type=str, default='127.0.0.1', help="IP address of the network interface to listen for HTTP connections. Specify 0.0.0.0 to listen on all interfaces.")
+    parser.add_argument("--allowed-origins", action='append', default=[], help="List of URLs to allow connection from, i.e. https://example.com. Allows http(s)://127.0.0.1:{port} and http(s)://localhost:{port} by default.")
 
     return parser
 
@@ -136,7 +138,7 @@ if __name__ == "MMVCServerSIO":
     mp.freeze_support()
 
     voiceChangerManager = VoiceChangerManager.get_instance(voiceChangerParams)
-    app_fastapi = MMVC_Rest.get_instance(voiceChangerManager, voiceChangerParams)
+    app_fastapi = MMVC_Rest.get_instance(voiceChangerManager, voiceChangerParams, PORT, args.allowed_origins)
     app_socketio = MMVC_SocketIOApp.get_instance(app_fastapi, voiceChangerManager)
 
 

--- a/server/mods/origins.py
+++ b/server/mods/origins.py
@@ -1,0 +1,24 @@
+from typing import Optional, Sequence
+from urllib.parse import urlparse
+
+ENFORCE_URL_ORIGIN_FORMAT = "Input origins must be well-formed URLs, i.e. https://google.com or https://www.google.com."
+SCHEMAS = ('http', 'https')
+LOCAL_ORIGINS = ('127.0.0.1', 'localhost')
+
+def compute_local_origins(port: Optional[int] = None) -> list[str]:
+    local_origins = [f'{schema}://{origin}' for schema in SCHEMAS for origin in LOCAL_ORIGINS]
+    if port is not None:
+        local_origins = [f'{origin}:{port}' for origin in local_origins]
+    return local_origins
+
+
+def normalize_origins(origins: Sequence[str]) -> set[str]:
+    allowed_origins = set()
+    for origin in origins:
+        url = urlparse(origin)
+        assert url.scheme, ENFORCE_URL_ORIGIN_FORMAT
+        valid_origin = f'{url.scheme}://{url.hostname}'
+        if url.port:
+            valid_origin += f':{url.port}'
+        allowed_origins.add(valid_origin)
+    return allowed_origins

--- a/server/restapi/MMVC_Rest.py
+++ b/server/restapi/MMVC_Rest.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, Request, Response, HTTPException
 from fastapi.routing import APIRoute
 from fastapi.staticfiles import StaticFiles
 from fastapi.exceptions import RequestValidationError
-from typing import Callable
+from typing import Callable, Optional, Sequence, Literal
 from mods.log_control import VoiceChangaerLogger
 from voice_changer.VoiceChangerManager import VoiceChangerManager
 
@@ -43,8 +43,8 @@ class MMVC_Rest:
         cls,
         voiceChangerManager: VoiceChangerManager,
         voiceChangerParams: VoiceChangerParams,
-        port: int,
-        allowedOrigins: list[str],
+        allowedOrigins: Optional[Sequence[str]] = None,
+        port: Optional[int] = None,
     ):
         if cls._instance is None:
             logger.info("[Voice Changer] MMVC_Rest initializing...")

--- a/server/restapi/MMVC_Rest.py
+++ b/server/restapi/MMVC_Rest.py
@@ -1,9 +1,9 @@
 import os
 import sys
 
+from restapi.mods.trustedorigin import TrustedOriginMiddleware
 from fastapi import FastAPI, Request, Response, HTTPException
 from fastapi.routing import APIRoute
-# from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.exceptions import RequestValidationError
 from typing import Callable
@@ -43,18 +43,18 @@ class MMVC_Rest:
         cls,
         voiceChangerManager: VoiceChangerManager,
         voiceChangerParams: VoiceChangerParams,
+        port: int,
+        allowedOrigins: list[str],
     ):
         if cls._instance is None:
             logger.info("[Voice Changer] MMVC_Rest initializing...")
             app_fastapi = FastAPI()
             app_fastapi.router.route_class = ValidationErrorLoggingRoute
-            # app_fastapi.add_middleware(
-            #     CORSMiddleware,
-            #     allow_origins=["*"],
-            #     allow_credentials=True,
-            #     allow_methods=["*"],
-            #     allow_headers=["*"],
-            # )
+            app_fastapi.add_middleware(
+                TrustedOriginMiddleware,
+                allowed_origins=allowedOrigins,
+                port=port
+            )
 
             app_fastapi.mount(
                 "/front",

--- a/server/restapi/mods/trustedorigin.py
+++ b/server/restapi/mods/trustedorigin.py
@@ -1,0 +1,49 @@
+import typing
+
+from urllib.parse import urlparse
+from starlette.datastructures import Headers
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+ENFORCE_URL_ORIGIN_FORMAT = "Input origins must be well-formed URLs, i.e. https://google.com or https://www.google.com."
+
+
+class TrustedOriginMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        allowed_origins: typing.Optional[typing.Sequence[str]] = None,
+        port: typing.Optional[int] = None,
+    ) -> None:
+        schemas = ['http', 'https']
+        local_origins = [f'{schema}://{origin}' for schema in schemas for origin in ['127.0.0.1', 'localhost']]
+        if port is not None:
+            local_origins = [f'{origin}:{port}' for origin in local_origins]
+
+        if not allowed_origins:
+            allowed_origins = local_origins
+        else:
+            for origin in allowed_origins:
+                assert urlparse(origin).scheme, ENFORCE_URL_ORIGIN_FORMAT
+            allowed_origins = local_origins + allowed_origins
+
+        self.app = app
+        self.allowed_origins = list(allowed_origins)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in (
+            "http",
+            "websocket",
+        ):  # pragma: no cover
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        origin = headers.get("origin", "")
+        # Origin header is not present for same origin
+        if not origin or origin in self.allowed_origins:
+            await self.app(scope, receive, send)
+            return
+
+        response = PlainTextResponse("Invalid origin header", status_code=400)
+        await response(scope, receive, send)

--- a/server/restapi/mods/trustedorigin.py
+++ b/server/restapi/mods/trustedorigin.py
@@ -1,35 +1,27 @@
-import typing
+from typing import Optional, Sequence, Literal
 
-from urllib.parse import urlparse
+from mods.origins import compute_local_origins, normalize_origins
 from starlette.datastructures import Headers
 from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
-
-ENFORCE_URL_ORIGIN_FORMAT = "Input origins must be well-formed URLs, i.e. https://google.com or https://www.google.com."
 
 
 class TrustedOriginMiddleware:
     def __init__(
         self,
         app: ASGIApp,
-        allowed_origins: typing.Optional[typing.Sequence[str]] = None,
-        port: typing.Optional[int] = None,
+        allowed_origins: Optional[Sequence[str]] = None,
+        port: Optional[int] = None,
     ) -> None:
-        schemas = ['http', 'https']
-        local_origins = [f'{schema}://{origin}' for schema in schemas for origin in ['127.0.0.1', 'localhost']]
-        if port is not None:
-            local_origins = [f'{origin}:{port}' for origin in local_origins]
-
         self.allowed_origins: set[str] = set()
-        if allowed_origins is not None:
-            for origin in allowed_origins:
-                url = urlparse(origin)
-                assert url.scheme, ENFORCE_URL_ORIGIN_FORMAT
-                valid_origin = f'{url.scheme}://{url.hostname}'
-                if url.port:
-                    valid_origin += f':{url.port}'
-                self.allowed_origins.add(valid_origin)
+
+        local_origins = compute_local_origins(port)
         self.allowed_origins.update(local_origins)
+
+        if allowed_origins is not None:
+            normalized_origins = normalize_origins(allowed_origins)
+            self.allowed_origins.update(normalized_origins)
+
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/server/sio/MMVC_SocketIOApp.py
+++ b/server/sio/MMVC_SocketIOApp.py
@@ -1,6 +1,8 @@
 import socketio
 from mods.log_control import VoiceChangaerLogger
+from mods.origins import compute_local_origins, normalize_origins
 
+from typing import Sequence, Optional
 from sio.MMVC_SocketIOServer import MMVC_SocketIOServer
 from voice_changer.VoiceChangerManager import VoiceChangerManager
 from const import getFrontendPath
@@ -12,10 +14,24 @@ class MMVC_SocketIOApp:
     _instance: socketio.ASGIApp | None = None
 
     @classmethod
-    def get_instance(cls, app_fastapi, voiceChangerManager: VoiceChangerManager):
+    def get_instance(
+        cls,
+        app_fastapi,
+        voiceChangerManager: VoiceChangerManager,
+        allowedOrigins: Optional[Sequence[str]] = None,
+        port: Optional[int] = None,
+    ):
         if cls._instance is None:
             logger.info("[Voice Changer] MMVC_SocketIOApp initializing...")
-            sio = MMVC_SocketIOServer.get_instance(voiceChangerManager)
+
+            allowed_origins: set[str] = set()
+            local_origins = compute_local_origins(port)
+            allowed_origins.update(local_origins)
+            if allowedOrigins is not None:
+                normalized_origins = normalize_origins(allowedOrigins)
+                allowed_origins.update(normalized_origins)
+            sio = MMVC_SocketIOServer.get_instance(voiceChangerManager, list(allowed_origins))
+
             app_socketio = socketio.ASGIApp(
                 sio,
                 other_asgi_app=app_fastapi,

--- a/server/sio/MMVC_SocketIOServer.py
+++ b/server/sio/MMVC_SocketIOServer.py
@@ -8,9 +8,13 @@ class MMVC_SocketIOServer:
     _instance: socketio.AsyncServer | None = None
 
     @classmethod
-    def get_instance(cls, voiceChangerManager: VoiceChangerManager):
+    def get_instance(
+        cls,
+        voiceChangerManager: VoiceChangerManager,
+        allowedOrigins: list[str],
+    ):
         if cls._instance is None:
-            sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
+            sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins=allowedOrigins)
             namespace = MMVC_Namespace.get_instance(voiceChangerManager)
             sio.register_namespace(namespace)
             cls._instance = sio


### PR DESCRIPTION
* Breaking change: set host to `127.0.0.1` by default to prevent external requests for local-only instances.
* Breaking change: add Origin header check to prevent requests execution from foreign origins.
* Add `--host` argument to specify host interface.
* Update print messages with URL. `127.0.0.1` is not allowed to have access to AudioContext in Chrome.
* Remove permissive CORS middleware.