### PR TITLE
Fix NumPy version to v1

### DIFF
--- a/server/requirements-common.txt
+++ b/server/requirements-common.txt
@@ -5,7 +5,7 @@
 
 uvicorn
 pyOpenSSL
-numpy
+numpy<2 # Not all modules have migrated to NumPy 2 yet. Using latest NumPy 1 version
 soxr
 python-socketio
 fastapi


### PR DESCRIPTION
NumPy v2 was releated on June 16. Required libs don't support it, so fix version to v1.